### PR TITLE
Finalize tests and docs

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,44 @@
+import zipfile
+from pathlib import Path
+import pytest
+
+from microlens_submit.api import load
+
+
+def test_full_lifecycle(tmp_path):
+    project = tmp_path / "proj"
+    sub = load(str(project))
+    sub.team_name = "Test Team"
+    sub.tier = "test"
+
+    evt = sub.get_event("test-event")
+    sol1 = evt.add_solution(model_type="test", parameters={"a": 1})
+    sol2 = evt.add_solution(model_type="test", parameters={"b": 2})
+    sub.save()
+
+    new_sub = load(str(project))
+    assert new_sub.team_name == "Test Team"
+    assert "test-event" in new_sub.events
+    new_evt = new_sub.events["test-event"]
+    assert sol1.solution_id in new_evt.solutions
+    assert sol2.solution_id in new_evt.solutions
+
+
+def test_deactivate_and_export(tmp_path):
+    project = tmp_path / "proj"
+    sub = load(str(project))
+    evt = sub.get_event("test-event")
+    sol_active = evt.add_solution("test", {"a": 1})
+    sol_inactive = evt.add_solution("test", {"b": 2})
+    sol_inactive.deactivate()
+    sub.save()
+
+    zip_path = project / "submission.zip"
+    sub.export(str(zip_path))
+
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as zf:
+        solution_files = [
+            n for n in zf.namelist() if n.startswith("events/") and "solutions" in n
+        ]
+    assert solution_files == [f"events/test-event/solutions/{sol_active.solution_id}.json"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,50 @@
+import zipfile
+from pathlib import Path
+import pytest
+from typer.testing import CliRunner
+
+from microlens_submit.cli import app
+from microlens_submit import api
+
+runner = CliRunner()
+
+
+def test_cli_init_and_add():
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["init", "--team-name", "Test Team", "--tier", "test"])
+        assert result.exit_code == 0
+        assert Path("submission.json").exists()
+
+        result = runner.invoke(
+            app,
+            ["add-solution", "test-event", "test", "--param", "p1=1"],
+        )
+        assert result.exit_code == 0
+        sol_id = result.stdout.strip()
+
+        sub = api.load(".")
+        evt = sub.get_event("test-event")
+        assert sol_id in evt.solutions
+        assert evt.solutions[sol_id].parameters["p1"] == 1
+
+
+def test_cli_export():
+    with runner.isolated_filesystem():
+        assert runner.invoke(app, ["init", "--team-name", "Team", "--tier", "test"]).exit_code == 0
+        sol1 = runner.invoke(
+            app,
+            ["add-solution", "evt", "test", "--param", "x=1"],
+        ).stdout.strip()
+        sol2 = runner.invoke(
+            app,
+            ["add-solution", "evt", "test", "--param", "y=2"],
+        ).stdout.strip()
+
+        assert runner.invoke(app, ["deactivate", sol2]).exit_code == 0
+        result = runner.invoke(app, ["export", "submission.zip"])
+        assert result.exit_code == 0
+        assert Path("submission.zip").exists()
+        with zipfile.ZipFile("submission.zip") as zf:
+            solution_files = [n for n in zf.namelist() if "solutions" in n]
+        assert solution_files == [f"events/evt/solutions/{sol1}.json"]
+


### PR DESCRIPTION
## Summary
- refine API docstrings with Google-style Args/Returns
- fix Submission.project_path parsing
- ensure forward references resolve
- add tests for API lifecycle and export
- add CLI integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68630e8c846c8328b977379551c30234