### PR TITLE
Add pre-commit and format codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+# .pre-commit-config.yaml
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+-   repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+    -   id: black
+
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+    -   id: isort

--- a/microlens_submit/__init__.py
+++ b/microlens_submit/__init__.py
@@ -1,5 +1,5 @@
 """microlens-submit public API."""
 
-from .api import Submission, Event, Solution, load
+from .api import Event, Solution, Submission, load
 
 __all__ = ["Submission", "Event", "Solution", "load"]

--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 """Core API for microlens-submit."""
 
-from pathlib import Path
-from datetime import datetime
 import json
 import uuid
 import zipfile
+from datetime import datetime
+from pathlib import Path
 from typing import Dict, Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -20,7 +21,9 @@ class Solution(BaseModel):
     is_active: bool = True
     compute_info: dict = Field(default_factory=dict)
     notes: str = ""
-    creation_timestamp: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    creation_timestamp: str = Field(
+        default_factory=lambda: datetime.utcnow().isoformat()
+    )
 
     def set_compute_info(self, cpu_hours: float | None = None) -> None:
         """Record basic compute metadata.
@@ -70,7 +73,9 @@ class Event(BaseModel):
             Solution: The newly created solution instance.
         """
         solution_id = str(uuid.uuid4())
-        sol = Solution(solution_id=solution_id, model_type=model_type, parameters=parameters)
+        sol = Solution(
+            solution_id=solution_id, model_type=model_type, parameters=parameters
+        )
         self.solutions[solution_id] = sol
         return sol
 
@@ -110,7 +115,9 @@ class Event(BaseModel):
         base = Path(self.submission.project_path) / "events" / self.event_id
         base.mkdir(parents=True, exist_ok=True)
         with (base / "event.json").open("w", encoding="utf-8") as fh:
-            fh.write(self.model_dump_json(exclude={"solutions", "submission"}, indent=2))
+            fh.write(
+                self.model_dump_json(exclude={"solutions", "submission"}, indent=2)
+            )
         for sol in self.solutions.values():
             sol._save(base)
 
@@ -142,11 +149,7 @@ class Submission(BaseModel):
         events_dir = project / "events"
         events_dir.mkdir(parents=True, exist_ok=True)
         with (project / "submission.json").open("w", encoding="utf-8") as fh:
-            fh.write(
-                self.model_dump_json(
-                    exclude={"events", "project_path"}, indent=2
-                )
-            )
+            fh.write(self.model_dump_json(exclude={"events", "project_path"}, indent=2))
         for event in self.events.values():
             event.submission = self
             event._save()
@@ -189,7 +192,9 @@ def load(project_path: str) -> Submission:
         events_dir.mkdir(parents=True, exist_ok=True)
         submission = Submission(project_path=str(project))
         with (project / "submission.json").open("w", encoding="utf-8") as fh:
-            fh.write(submission.model_dump_json(exclude={"events", "project_path"}, indent=2))
+            fh.write(
+                submission.model_dump_json(exclude={"events", "project_path"}, indent=2)
+            )
         return submission
 
     sub_json = project / "submission.json"

--- a/microlens_submit/cli.py
+++ b/microlens_submit/cli.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import json
+from pathlib import Path
+
 import typer
 
 from .api import load

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,7 @@ dev = [
     "pytest-cov",
     "build",
     "twine",
+    "pre-commit",
+    "black",
+    "isort",
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import zipfile
 from pathlib import Path
+
 import pytest
 
 from microlens_submit.api import load
@@ -41,4 +42,6 @@ def test_deactivate_and_export(tmp_path):
         solution_files = [
             n for n in zf.namelist() if n.startswith("events/") and "solutions" in n
         ]
-    assert solution_files == [f"events/test-event/solutions/{sol_active.solution_id}.json"]
+    assert solution_files == [
+        f"events/test-event/solutions/{sol_active.solution_id}.json"
+    ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,20 @@
 import zipfile
 from pathlib import Path
+
 import pytest
 from typer.testing import CliRunner
 
-from microlens_submit.cli import app
 from microlens_submit import api
+from microlens_submit.cli import app
 
 runner = CliRunner()
 
 
 def test_cli_init_and_add():
     with runner.isolated_filesystem():
-        result = runner.invoke(app, ["init", "--team-name", "Test Team", "--tier", "test"])
+        result = runner.invoke(
+            app, ["init", "--team-name", "Test Team", "--tier", "test"]
+        )
         assert result.exit_code == 0
         assert Path("submission.json").exists()
 
@@ -30,7 +33,12 @@ def test_cli_init_and_add():
 
 def test_cli_export():
     with runner.isolated_filesystem():
-        assert runner.invoke(app, ["init", "--team-name", "Team", "--tier", "test"]).exit_code == 0
+        assert (
+            runner.invoke(
+                app, ["init", "--team-name", "Team", "--tier", "test"]
+            ).exit_code
+            == 0
+        )
         sol1 = runner.invoke(
             app,
             ["add-solution", "evt", "test", "--param", "x=1"],
@@ -47,4 +55,3 @@ def test_cli_export():
         with zipfile.ZipFile("submission.zip") as zf:
             solution_files = [n for n in zf.namelist() if "solutions" in n]
         assert solution_files == [f"events/evt/solutions/{sol1}.json"]
-


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` for automated checks
- include black, isort and pre-commit in development dependencies
- apply isort and black formatting across the project

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863129266a88328ab36e80b70ab2470