### PR TITLE
Fix CLI section formatting and typographical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A stateful submission toolkit for the RGES-PIT Microlensing Data Challenge.
 
 ## Installation
 
-This package is pre-release. It is currently available on TestPyPl:
+This package is pre-release. It is currently available on TestPyPI:
 
 ```bash
 pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple microlens-submit==0.1.0
@@ -30,20 +30,28 @@ The package will be available on PyPI:
 pip install microlens-submit
 ```
 
-QuickstartUsing the Command Line Interface (CLI)The CLI is the recommended way to interact with your submission project.
+### Quickstart Using the Command Line Interface (CLI)
+
+The CLI is the recommended way to interact with your submission project.
 
 1. Initialize your project: `microlens-submit init --team-name "Planet Pounders" --tier "advanced"`
-2. Add a new solution to an event:`microlens-submit add-solution ogle-2025-blg-0042 \`
-    `--model-type binary_lens \`
-    `--param t0=555.5 \`
-    `--param u0=0.1 \`
-    `--param tE=25.0 \`
-    `--notes "This is a great fit!"`
-  This will create a new solution and print its unique `solution_id`.
+2. Add a new solution to an event:
+   ```bash
+   microlens-submit add-solution ogle-2025-blg-0042 \
+       --model-type binary_lens \
+       --param t0=555.5 \
+       --param u0=0.1 \
+       --param tE=25.0 \
+       --notes "This is a great fit!"
+   ```
+   This will create a new solution and print its unique `solution_id`.
 3. Deactivate a solution that didn't work out: `microlens-submit deactivate <solution_id>`
 4. List all solutions for an event: `microlens-submit list-solutions ogle-2025-blg-0042`
 5. Export your final submission: `microlens-submit export --output "final_submission.zip"`
-  Using the Python APIFor those who want to integrate the tool directly into their Python analysis pipeline.
+
+### Using the Python API
+
+For those who want to integrate the tool directly into their Python analysis pipeline.
 
 ```python
 import microlens_submit


### PR DESCRIPTION
## Summary
- fix TestPyPl typo in README
- add missing line break after the CLI heading
- improve numbered list formatting
- split out "Using the Python API" as its own heading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863424dd7c4832887b702cff1e82222