### PR TITLE
Replace print with logging

### DIFF
--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Core API for microlens-submit."""
 
 import json
+import logging
 import subprocess
 import sys
 import uuid
@@ -44,7 +45,7 @@ class Solution(BaseModel):
                 result.stdout.strip().split("\n") if result.stdout else []
             )
         except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            print(f"Warning: Could not capture pip environment: {e}")
+            logging.warning("Could not capture pip environment: %s", e)
             self.compute_info["dependencies"] = []
 
     def deactivate(self) -> None:


### PR DESCRIPTION
## Summary
- add `import logging` in api module
- log missing environment capture warning with `logging.warning`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68634264c140832882112732958f544b