### PR TITLE
Add --no-color flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pip install microlens-submit
 
 QuickstartUsing the Command Line Interface (CLI)The CLI is the recommended way to interact with your submission project.
 
+You can pass ``--no-color`` to any command if your terminal does not support ANSI colors.
+
 1. Initialize your project: `microlens-submit init --team-name "Planet Pounders" --tier "advanced"`
 2. Add a new solution to an event:`microlens-submit add-solution ogle-2025-blg-0042 \`
     `--model-type binary_lens \`

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -3,6 +3,8 @@ Getting Started: A Step-by-Step Tutorial
 
 This quick guide walks you through the typical workflow using the ``microlens-submit`` CLI.
 
+If your terminal does not support ANSI escape codes, add ``--no-color`` to disable colored output.
+
 1. **Initialize your project**
 
    .. code-block:: bash

--- a/microlens_submit/cli.py
+++ b/microlens_submit/cli.py
@@ -17,6 +17,17 @@ console = Console()
 app = typer.Typer()
 
 
+@app.callback()
+def main(
+    ctx: typer.Context,
+    no_color: bool = typer.Option(False, "--no-color", help="Disable colored output"),
+) -> None:
+    """Handle global options."""
+    if no_color:
+        global console
+        console = Console(color_system=None)
+
+
 @app.command()
 def init(
     team_name: str = typer.Option(..., help="Team name"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,16 @@ from microlens_submit.cli import app
 runner = CliRunner()
 
 
+def test_global_no_color_option():
+    """The --no-color flag disables ANSI color codes."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            app,
+            ["--no-color", "init", "--team-name", "Team", "--tier", "test"],
+        )
+        assert result.exit_code == 0
+        assert "\x1b[" not in result.stdout
+
 def test_cli_init_and_add():
     with runner.isolated_filesystem():
         result = runner.invoke(


### PR DESCRIPTION
## Summary
- allow disabling colored console output with `--no-color`
- document the flag in the README and tutorial
- test that the option works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863427275988328aadaa54302477d9e