### PR TITLE
Fix tests for lint cleanliness

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,4 @@
 import zipfile
-from pathlib import Path
-
-import pytest
 
 from microlens_submit.api import load
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,5 @@
 import zipfile
 from pathlib import Path
-
-import pytest
 from typer.testing import CliRunner
 
 from microlens_submit import api
@@ -40,13 +38,19 @@ def test_cli_export():
             ).exit_code
             == 0
         )
-        res1 = runner.invoke(
-            app,
-            ["add-solution", "evt", "test", "--param", "x=1"],
+        assert (
+            runner.invoke(
+                app,
+                ["add-solution", "evt", "test", "--param", "x=1"],
+            ).exit_code
+            == 0
         )
-        res2 = runner.invoke(
-            app,
-            ["add-solution", "evt", "test", "--param", "y=2"],
+        assert (
+            runner.invoke(
+                app,
+                ["add-solution", "evt", "test", "--param", "y=2"],
+            ).exit_code
+            == 0
         )
         sub = api.load(".")
         evt = sub.get_event("evt")
@@ -67,8 +71,14 @@ def test_cli_list_solutions():
             runner.invoke(app, ["init", "--team-name", "Team", "--tier", "test"]).exit_code
             == 0
         )
-        res_a = runner.invoke(app, ["add-solution", "evt", "test", "--param", "a=1"])
-        res_b = runner.invoke(app, ["add-solution", "evt", "test", "--param", "b=2"])
+        assert (
+            runner.invoke(app, ["add-solution", "evt", "test", "--param", "a=1"]).exit_code
+            == 0
+        )
+        assert (
+            runner.invoke(app, ["add-solution", "evt", "test", "--param", "b=2"]).exit_code
+            == 0
+        )
         sub = api.load(".")
         evt = sub.get_event("evt")
         ids = list(evt.solutions.keys())


### PR DESCRIPTION
## Summary
- clean up unused imports
- remove unused variables in CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686342749e30832888d1042c68eafa40