### PR TITLE
Add posterior path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A stateful submission toolkit for the RGES-PIT Microlensing Data Challenge.
 * **Solution Management:** Easily add, update, and deactivate degenerate solutions for any event without losing your work history.
 * **Automatic Validation:** Aggressive data validation powered by Pydantic ensures your submission is always compliant with the challenge rules.
 * **Environment Capture:** Automatically records your Python dependencies for each specific model fit, ensuring reproducibility.
+* **Optional Posterior Storage:** Record the path to posterior samples for any solution.
 * **Simple Export:** Packages all your active solutions into a clean, standardized `.zip` archive for final submission.
 
 ## Installation

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -17,26 +17,37 @@ This quick guide walks you through the typical workflow using the ``microlens-su
           --param t0=555.5 --param u0=0.1 --param tE=25.0 \
           --notes "Initial fit"
 
-3. **Add a competing solution**
+3. **Attach a posterior file (optional)**
+
+   After generating a posterior sample (e.g., an MCMC chain), store the file
+   within your project and record its relative path using the Python API::
+
+      >>> sub = microlens_submit.load("/path/to/project")
+      >>> evt = sub.get_event("EVENT123")
+      >>> sol = next(iter(evt.solutions.values()))
+      >>> sol.posterior_path = "posteriors/chain.h5"
+      >>> sub.save()
+
+4. **Add a competing solution**
 
    .. code-block:: bash
 
       microlens-submit add-solution EVENT123 single_lens \
           --param t0=556.0 --param u0=0.2 --param tE=24.5
 
-4. **List your solutions**
+5. **List your solutions**
 
    .. code-block:: bash
 
       microlens-submit list-solutions EVENT123
 
-5. **Deactivate the less-good solution**
+6. **Deactivate the less-good solution**
 
    .. code-block:: bash
 
       microlens-submit deactivate <solution_id>
 
-6. **Export the final package**
+7. **Export the final package**
 
    .. code-block:: bash
 

--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -22,7 +22,7 @@ class Solution(BaseModel):
     parameters: dict
     is_active: bool = True
     compute_info: dict = Field(default_factory=dict)
-    posterior_path: str | None = None
+    posterior_path: Optional[str] = None
     notes: str = ""
     creation_timestamp: str = Field(
         default_factory=lambda: datetime.utcnow().isoformat()

--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -22,6 +22,7 @@ class Solution(BaseModel):
     parameters: dict
     is_active: bool = True
     compute_info: dict = Field(default_factory=dict)
+    posterior_path: str | None = None
     notes: str = ""
     creation_timestamp: str = Field(
         default_factory=lambda: datetime.utcnow().isoformat()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,3 +50,16 @@ def test_deactivate_and_export(tmp_path):
     assert solution_files == [
         f"events/test-event/solutions/{sol_active.solution_id}.json"
     ]
+
+
+def test_posterior_path_persists(tmp_path):
+    project = tmp_path / "proj"
+    sub = load(str(project))
+    evt = sub.get_event("event")
+    sol = evt.add_solution("test", {"x": 1})
+    sol.posterior_path = "posteriors/post.h5"
+    sub.save()
+
+    new_sub = load(str(project))
+    new_sol = new_sub.events["event"].solutions[sol.solution_id]
+    assert new_sol.posterior_path == "posteriors/post.h5"


### PR DESCRIPTION
## Summary
- add `posterior_path` field to `Solution`
- document optional posterior storage in README and tutorial
- test persistence of `posterior_path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863430141ac83288ed0aaf8b70ab955