### PR TITLE
Add active solution helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A stateful submission toolkit for the RGES-PIT Microlensing Data Challenge.
 * **Persistent Projects:** Treat your submission as a local project that you can load, edit, and save over weeks or months.
 * **Python API & CLI:** Use the tool directly in your Python analysis scripts or via the command line.
 * **Solution Management:** Easily add, update, and deactivate degenerate solutions for any event without losing your work history.
+* **Active Solution Control:** Quickly list just the active solutions or mark
+  all solutions inactive in one call.
 * **Automatic Validation:** Aggressive data validation powered by Pydantic ensures your submission is always compliant with the challenge rules.
 * **Environment Capture:** Automatically records your Python dependencies for each specific model fit, ensuring reproducibility.
 * **Simple Export:** Packages all your active solutions into a clean, standardized `.zip` archive for final submission.

--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -107,6 +107,17 @@ class Event(BaseModel):
         """
         return self.solutions[solution_id]
 
+    def get_active_solutions(self) -> list[Solution]:
+        """Return all active solutions for this event."""
+
+        return [sol for sol in self.solutions.values() if sol.is_active]
+
+    def clear_solutions(self) -> None:
+        """Mark all solutions inactive without deleting them."""
+
+        for sol in self.solutions.values():
+            sol.is_active = False
+
     @classmethod
     def _from_dir(cls, event_dir: Path, submission: "Submission") -> "Event":
         """Load an event from disk."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,3 +47,35 @@ def test_deactivate_and_export(tmp_path):
     assert solution_files == [
         f"events/test-event/solutions/{sol_active.solution_id}.json"
     ]
+
+
+def test_get_active_solutions(tmp_path):
+    project = tmp_path / "proj"
+    sub = load(str(project))
+    evt = sub.get_event("evt")
+    sol1 = evt.add_solution("test", {"a": 1})
+    sol2 = evt.add_solution("test", {"b": 2})
+    sol2.deactivate()
+
+    actives = evt.get_active_solutions()
+
+    assert len(actives) == 1
+    assert actives[0].solution_id == sol1.solution_id
+
+
+def test_clear_solutions(tmp_path):
+    project = tmp_path / "proj"
+    sub = load(str(project))
+    evt = sub.get_event("evt")
+    sol1 = evt.add_solution("test", {"a": 1})
+    sol2 = evt.add_solution("test", {"b": 2})
+
+    evt.clear_solutions()
+    sub.save()
+
+    reloaded = load(str(project))
+    evt2 = reloaded.get_event("evt")
+
+    assert not evt2.solutions[sol1.solution_id].is_active
+    assert not evt2.solutions[sol2.solution_id].is_active
+    assert len(evt2.solutions) == 2


### PR DESCRIPTION
## Summary
- allow retrieving only active solutions
- allow clearing all solutions on an event
- document new functionality in README
- test the new helper methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68634612de2c8328ad00821a34a9bd60