### PR TITLE
Support wall clock time metadata

### DIFF
--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -31,11 +31,22 @@ class Solution(BaseModel):
         default_factory=lambda: datetime.utcnow().isoformat()
     )
 
-    def set_compute_info(self, cpu_hours: float | None = None) -> None:
-        """Record compute metadata and capture Python environment."""
+    def set_compute_info(
+        self,
+        cpu_hours: float | None = None,
+        wall_time_hours: float | None = None,
+    ) -> None:
+        """Record compute metadata and capture Python environment.
+
+        Args:
+            cpu_hours: Total CPU time consumed for this solution in hours.
+            wall_time_hours: Total wall-clock time for this solution in hours.
+        """
 
         if cpu_hours is not None:
             self.compute_info["cpu_hours"] = cpu_hours
+        if wall_time_hours is not None:
+            self.compute_info["wall_time_hours"] = wall_time_hours
 
         try:
             result = subprocess.run(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,6 +27,21 @@ def test_full_lifecycle(tmp_path):
     assert any("pytest" in dep for dep in new_sol1.compute_info["dependencies"])
 
 
+def test_compute_info_hours(tmp_path):
+    """CPU and wall time are persisted."""
+    project = tmp_path / "proj"
+    sub = load(str(project))
+    evt = sub.get_event("evt")
+    sol = evt.add_solution(model_type="test", parameters={})
+    sol.set_compute_info(cpu_hours=1.5, wall_time_hours=2.0)
+    sub.save()
+
+    new_sub = load(str(project))
+    new_sol = new_sub.get_event("evt").solutions[sol.solution_id]
+    assert new_sol.compute_info["cpu_hours"] == 1.5
+    assert new_sol.compute_info["wall_time_hours"] == 2.0
+
+
 def test_deactivate_and_export(tmp_path):
     project = tmp_path / "proj"
     sub = load(str(project))


### PR DESCRIPTION
## Summary
- extend `Solution.set_compute_info` to record optional wall clock time
- document `wall_time_hours` argument
- test CPU and wall time persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863463f4b048328b1a3c64c4d3d5c8f