### PR TITLE
Implement Nexus integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Release v0.5.0
+
+### What's New
+- Added `nexus-init` command to capture platform metadata on the Roman Research Nexus.
+- `Submission.autofill_nexus_info` auto-populates hardware details from the environment.
+- New Jupyter notebook tutorial for Nexus users.
+
+### Bug Fixes
+- N/A
+
+### Breaking Changes
+- None
+
+### Dependencies
+- No dependency changes
+
 ## Release v0.4.0
 
 ### What's New

--- a/agents.md
+++ b/agents.md
@@ -393,7 +393,7 @@ For future automation, consider implementing:
 - **v0.2.0:** ✅ Released - Feature Batch 1 (Provenance Capture, Structured Metadata, Hardware Info)
 - **v0.3.0:** ✅ Released - Feature Batch 2 (Solution Comparison, Pre-flight Validation)
 - **v0.4.0:** ✅ Released - DIY Support Package (Manual and Validation Tools)
-- **v0.5.0:** 📋 Planned - Seemless Nexus Integration
+- **v0.5.0:** 🚧 In Development - Seamless Nexus Integration
 - **v0.6.0:** 📋 Planned - Model Validation
 - **v1.0.0:** 📋 Planned - Official Release
 

--- a/docs/Submission_Tool_Tutorial.ipynb
+++ b/docs/Submission_Tool_Tutorial.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Microlens-Submit on the Roman Research Nexus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial demonstrates how to use `microlens-submit` within the Roman Research Nexus environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install microlens-submit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!microlens-submit nexus-init --team-name \"My Nexus Team\" --tier \"advanced\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from microlens_submit import load\n",
+    "submission = load(\".\")\n",
+    "print(submission.hardware_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add solutions and export the project using the CLI." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!microlens-submit add-solution my-event binary_lens --param t0=123.4 --param u0=0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!microlens-submit export submission.zip --force"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/microlens_submit/cli.py
+++ b/microlens_submit/cli.py
@@ -65,6 +65,21 @@ def init(
     console.print(Panel(f"Initialized project at {project_path}", style="bold green"))
 
 
+@app.command("nexus-init")
+def nexus_init(
+    team_name: str = typer.Option(..., help="Team name"),
+    tier: str = typer.Option(..., help="Challenge tier"),
+    project_path: Path = typer.Argument(Path("."), help="Project directory"),
+) -> None:
+    """Initialize a project and capture Roman Nexus platform info."""
+
+    init(team_name=team_name, tier=tier, project_path=project_path)
+    sub = load(str(project_path))
+    sub.autofill_nexus_info()
+    sub.save()
+    console.print("Nexus platform info captured.", style="bold green")
+
+
 @app.command("add-solution")
 def add_solution(
     event_id: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "microlens-submit"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
   { name="Amber Malpas", email="malpas.1@Oosu.edu" },
 ]


### PR DESCRIPTION
## Summary
- implement `Submission.autofill_nexus_info()` to capture Nexus metadata
- add `nexus-init` command that auto-populates hardware info
- provide a Jupyter notebook tutorial
- bump version to v0.5.0
- update roadmap and changelog

## Testing
- `black . --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68643f3743e8832890367d9b1084472d