### PR TITLE
Add submission.json to export zip

### DIFF
--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -377,6 +377,9 @@ class Submission(BaseModel):
         """
         project = Path(self.project_path)
         with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            submission_json = project / "submission.json"
+            if submission_json.exists():
+                zf.write(submission_json, arcname="submission.json")
             events_dir = project / "events"
             for event in self.events.values():
                 event_dir = events_dir / event.event_id

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,9 +56,11 @@ def test_deactivate_and_export(tmp_path):
 
     assert zip_path.exists()
     with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
         solution_files = [
-            n for n in zf.namelist() if n.startswith("events/") and "solutions" in n
+            n for n in names if n.startswith("events/") and "solutions" in n
         ]
+        assert "submission.json" in names
     assert solution_files == [
         f"events/test-event/solutions/{sol_active.solution_id}.json"
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,9 @@ def test_cli_export():
         assert result.exit_code == 0
         assert Path("submission.zip").exists()
         with zipfile.ZipFile("submission.zip") as zf:
-            solution_files = [n for n in zf.namelist() if "solutions" in n]
+            names = zf.namelist()
+            solution_files = [n for n in names if "solutions" in n]
+            assert "submission.json" in names
         assert solution_files == [f"events/evt/solutions/{sol1}.json"]
 
 


### PR DESCRIPTION
## Summary
- include submission.json when generating export archives
- assert submission.json exists in export in API and CLI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645b3baa1c83289618e9c76f033034