### PR TITLE
Skip invalid n_data_points in compare

### DIFF
--- a/microlens_submit/cli.py
+++ b/microlens_submit/cli.py
@@ -263,11 +263,17 @@ def compare_solutions(
         raise typer.Exit(code=1)
 
     evt = sub.events[event_id]
-    solutions = [
-        s
-        for s in evt.get_active_solutions()
-        if s.log_likelihood is not None and s.n_data_points is not None
-    ]
+    solutions = []
+    for s in evt.get_active_solutions():
+        if s.log_likelihood is None or s.n_data_points is None:
+            continue
+        if s.n_data_points <= 0:
+            console.print(
+                f"Skipping {s.solution_id}: n_data_points <= 0",
+                style="bold red",
+            )
+            continue
+        solutions.append(s)
 
     table = Table(title=f"Solution Comparison for {event_id}")
     table.add_column("Solution ID")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,6 +150,54 @@ def test_cli_compare_solutions():
         assert "BIC" in result.stdout
 
 
+def test_cli_compare_solutions_skips_zero_data_points():
+    """Solutions with non-positive n_data_points are ignored."""
+    with runner.isolated_filesystem():
+        assert (
+            runner.invoke(
+                app, ["init", "--team-name", "Team", "--tier", "test"]
+            ).exit_code
+            == 0
+        )
+        result = runner.invoke(
+            app,
+            [
+                "add-solution",
+                "evt",
+                "model1",
+                "--param",
+                "x=1",
+                "--log-likelihood",
+                "-5",
+                "--n-data-points",
+                "0",
+            ],
+        )
+        assert result.exit_code == 0
+        result = runner.invoke(
+            app,
+            [
+                "add-solution",
+                "evt",
+                "model2",
+                "--param",
+                "y=2",
+                "--log-likelihood",
+                "-6",
+                "--n-data-points",
+                "10",
+            ],
+        )
+        assert result.exit_code == 0
+
+        result = runner.invoke(app, ["compare-solutions", "evt"])
+        assert result.exit_code == 0
+        # Only the valid solution should appear in the table
+        assert "model2" in result.stdout
+        assert "model1" not in result.stdout
+        assert "Skipping" in result.stdout
+
+
 def test_params_file_option_and_model_name():
     with runner.isolated_filesystem():
         assert (


### PR DESCRIPTION
## Summary
- avoid BIC computation when `n_data_points` is non-positive
- add CLI test covering zero-data-point solutions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645b570c508328be3711356918d514