### PR TITLE
Fix README export example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sol.notes = "This fit was generated from our Python script."
 sub.save()
 
 # When ready, export the final package
-sub.export(filename="final_submission.zip")
+sub.export("final_submission.zip")
 ```
 
 ## Development


### PR DESCRIPTION
## Summary
- fix Python API usage example in README

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686465af396883289ab77b84ec3ae282