### PR TITLE
Fix README install version to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # microlens-submit
 A stateful submission toolkit for the RGES-PIT Microlensing Data Challenge.
 
-[![PyPI version](https://badge.fury.io/py/microlens-submit.svg)](https://badge.fury.io/py/microlens-submit)
+[![PyPI - v0.6.0](https://img.shields.io/pypi/v/microlens-submit.svg)](https://pypi.org/project/microlens-submit/)
 [![CI](https://github.com/AmberLee2427/microlens-submit/actions/workflows/ci.yml/badge.svg)](https://github.com/AmberLee2427/microlens-submit/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -26,7 +26,7 @@ Full documentation is hosted on [Read the Docs](https://microlens-submit.readthe
 This package is pre-release. It is currently available on TestPyPI:
 
 ```bash
-pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple microlens-submit==0.1.0
+pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple microlens-submit==0.6.0
 ```
 
 The package will be available on PyPI:


### PR DESCRIPTION
## Summary
- bump install instructions to use version 0.6.0
- update PyPI badge to show the latest release

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686465b607ec8328b09e3863e7d088d2