### PR TITLE
Add dry-run validator to add-solution command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Release v0.6.1
+
+### What's New
+- `add-solution` supports a `--dry-run` flag to validate inputs without saving.
+
+### Bug Fixes
+- N/A
+
+### Breaking Changes
+- None
+
+### Dependencies
+- No dependency changes
+
 ## Release v0.6.0
 
 ### What's New

--- a/microlens_submit/cli.py
+++ b/microlens_submit/cli.py
@@ -136,6 +136,11 @@ def add_solution(
         help="Number of data points used in this solution",
     ),
     notes: str = typer.Option("", help="Notes for the solution"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Parse inputs and display the resulting Solution without saving",
+    ),
     project_path: Path = typer.Argument(Path("."), help="Project directory"),
 ) -> None:
     """Add a new solution entry for ``event_id``.
@@ -176,6 +181,30 @@ def add_solution(
     sol.log_likelihood = log_likelihood
     sol.log_prior = log_prior
     sol.n_data_points = n_data_points
+
+    if dry_run:
+        parsed = {
+            "event_id": event_id,
+            "model_type": model_type,
+            "parameters": params,
+            "model_name": model_name,
+            "used_astrometry": used_astrometry,
+            "used_postage_stamps": used_postage_stamps,
+            "limb_darkening_model": limb_darkening_model,
+            "limb_darkening_coeffs": _parse_pairs(limb_darkening_coeff),
+            "parameter_uncertainties": _parse_pairs(parameter_uncertainty),
+            "physical_parameters": _parse_pairs(physical_param),
+            "log_likelihood": log_likelihood,
+            "log_prior": log_prior,
+            "n_data_points": n_data_points,
+            "notes": notes,
+        }
+        console.print(Panel("Parsed Input", style="cyan"))
+        console.print(json.dumps(parsed, indent=2))
+        console.print(Panel("Schema Output", style="cyan"))
+        console.print(sol.model_dump_json(indent=2))
+        return
+
     sub.save()
     console.print(f"Created solution: [bold cyan]{sol.solution_id}[/bold cyan]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "microlens-submit"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   { name="Amber Malpas", email="malpas.1@Oosu.edu" },
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,6 +244,33 @@ def test_params_file_option_and_model_name():
         assert result.exit_code != 0
 
 
+def test_add_solution_dry_run():
+    """--dry-run prints info without saving to disk."""
+    with runner.isolated_filesystem():
+        assert (
+            runner.invoke(
+                app, ["init", "--team-name", "Team", "--tier", "test"]
+            ).exit_code
+            == 0
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "add-solution",
+                "evt",
+                "model",
+                "--param",
+                "x=1",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Parsed Input" in result.stdout
+        assert "Schema Output" in result.stdout
+        assert not Path("events/evt").exists()
+
+
 def test_cli_activate():
     with runner.isolated_filesystem():
         assert (


### PR DESCRIPTION
## Summary
- allow CLI users to validate input without saving using `--dry-run`
- record the new option in the changelog
- bump patch version to 0.6.1
- test dry-run behaviour

## Testing
- `black . --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647c71c46883288a360d5385647fed