### PR TITLE
Add dry-run examples to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Release v0.6.1
+
+### What's New
+- `add-solution` supports a `--dry-run` flag to validate inputs without saving.
+
+### Bug Fixes
+- N/A
+
+### Breaking Changes
+- None
+
+### Dependencies
+- No dependency changes
+
 ## Release v0.6.0
 
 ### What's New

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ You can pass ``--no-color`` to any command if your terminal does not support ANS
        --notes "This is a great fit!"
    ```
    This will create a new solution and print its unique `solution_id`.
+   You can run the same command with `--dry-run` first to verify the
+   parsed input without saving anything.
 3. Deactivate a solution that didn't work out: `microlens-submit deactivate <solution_id>`
 4. List all solutions for an event: `microlens-submit list-solutions ogle-2025-blg-0042`
 5. Export your final submission: `microlens-submit export --output "final_submission.zip"`

--- a/docs/Submission_Tool_Tutorial.ipynb
+++ b/docs/Submission_Tool_Tutorial.ipynb
@@ -104,7 +104,7 @@
     "# Save the initial configuration\n",
     "submission.save()\n",
     "\n",
-    "print(f\"✅ Project initialized at: {project_path}\")\n",
+    "print(f\"\u2705 Project initialized at: {project_path}\")\n",
     "print(f\"Team: {submission.team_name}\")\n",
     "print(f\"Tier: {submission.tier}\")"
    ]
@@ -154,7 +154,7 @@
     "    wall_time_hours=0.5\n",
     ")\n",
     "\n",
-    "print(f\"✅ Added solution: {solution_1.solution_id}\")\n",
+    "print(f\"\u2705 Added solution: {solution_1.solution_id}\")\n",
     "print(f\"Model type: {solution_1.model_type}\")\n",
     "print(f\"Parameters: {solution_1.parameters}\")"
    ]
@@ -185,9 +185,9 @@
     "\n",
     "# Add physical parameters derived from the fit\n",
     "solution_2.physical_parameters = {\n",
-    "    \"M_L\": 0.45,         # Lens mass (M☉)\n",
+    "    \"M_L\": 0.45,         # Lens mass (M\u2609)\n",
     "    \"D_L\": 6.2,          # Lens distance (kpc)\n",
-    "    \"M_planet\": 1.5,     # Planet mass (M⊕)\n",
+    "    \"M_planet\": 1.5,     # Planet mass (M\u2295)\n",
     "    \"a\": 2.8             # Semi-major axis (AU)\n",
     "}\n",
     "\n",
@@ -211,7 +211,7 @@
     "    wall_time_hours=3.8\n",
     ")\n",
     "\n",
-    "print(f\"✅ Added binary solution: {solution_2.solution_id}\")\n",
+    "print(f\"\u2705 Added binary solution: {solution_2.solution_id}\")\n",
     "print(f\"Log-likelihood improvement: {solution_1.log_likelihood - solution_2.log_likelihood:.2f}\")"
    ]
   },
@@ -264,7 +264,7 @@
     "\n",
     "solution_3.set_compute_info(cpu_hours=28.5, wall_time_hours=7.2)\n",
     "\n",
-    "print(f\"✅ Added solution for {event_002.event_id}: {solution_3.solution_id}\")"
+    "print(f\"\u2705 Added solution for {event_002.event_id}: {solution_3.solution_id}\")"
    ]
   },
   {
@@ -355,11 +355,11 @@
    "source": [
     "# Save current state\n",
     "submission.save()\n",
-    "print(\"✅ Project state saved\")\n",
+    "print(\"\u2705 Project state saved\")\n",
     "\n",
     "# Reload the project (useful for long-running analyses)\n",
     "reloaded_submission = microlens_submit.load(project_path)\n",
-    "print(f\"✅ Reloaded project with {len(reloaded_submission.events)} events\")\n",
+    "print(f\"\u2705 Reloaded project with {len(reloaded_submission.events)} events\")\n",
     "\n",
     "# Check that our solutions are still there\n",
     "for event_id, event in reloaded_submission.events.items():\n",
@@ -383,6 +383,28 @@
    "source": [
     "# Initialize project via CLI\n",
     "!microlens-submit init --team-name \"CLI Example Team\" --tier \"intermediate\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For quick validation, you can run `add-solution` with `--dry-run` to see the parsed input and schema output without saving anything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!microlens-submit add-solution KMT-2025-BLG-001 \\\n",
+    "    --model-type single_lens \\\n",
+    "    --param t0=2459123.5 \\\n",
+    "    --param u0=0.15 \\\n",
+    "    --param tE=20.5 \\\n",
+    "    --log-likelihood -1234.56 \\\n",
+    "    --dry-run"
    ]
   },
   {
@@ -428,7 +450,7 @@
    "source": [
     "# Export the final submission\n",
     "submission.export(filename=\"planet_hunters_final_submission.zip\")\n",
-    "print(\"✅ Final submission exported!\")\n",
+    "print(\"\u2705 Final submission exported!\")\n",
     "\n",
     "# Check what's included\n",
     "import zipfile\n",
@@ -483,7 +505,7 @@
     "3. **Join the community** for questions and support\n",
     "4. **Start your own microlensing analysis** with confidence!\n",
     "\n",
-    "Happy modeling! 🪐"
+    "Happy modeling! \ud83e\ude90"
    ]
   }
  ],

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -27,7 +27,18 @@ If your terminal does not support ANSI escape codes, add ``--no-color`` to disab
       microlens-submit add-solution EVENT123 binary_lens \
           --params-file params.json --notes "Initial fit"
 
-3. **Attach a posterior file (optional)**
+3. **Validate without saving**
+
+   .. code-block:: bash
+
+      microlens-submit add-solution EVENT123 binary_lens \
+          --param t0=555.5 --param u0=0.1 --param tE=25.0 \
+          --dry-run
+
+   This prints the parsed input and resulting schema output without writing
+   anything to disk.
+
+4. **Attach a posterior file (optional)**
 
    After generating a posterior sample (e.g., an MCMC chain), store the file
    within your project and record its relative path using the Python API::
@@ -38,26 +49,26 @@ If your terminal does not support ANSI escape codes, add ``--no-color`` to disab
       >>> sol.posterior_path = "posteriors/chain.h5"
       >>> sub.save()
 
-4. **Add a competing solution**
+5. **Add a competing solution**
 
    .. code-block:: bash
 
       microlens-submit add-solution EVENT123 single_lens \
           --param t0=556.0 --param u0=0.2 --param tE=24.5
 
-5. **List your solutions**
+6. **List your solutions**
 
    .. code-block:: bash
 
       microlens-submit list-solutions EVENT123
 
-6. **Deactivate the less-good solution**
+7. **Deactivate the less-good solution**
 
    .. code-block:: bash
 
       microlens-submit deactivate <solution_id>
 
-7. **Export the final package**
+8. **Export the final package**
 
    .. code-block:: bash
 

--- a/microlens_submit/cli.py
+++ b/microlens_submit/cli.py
@@ -136,6 +136,11 @@ def add_solution(
         help="Number of data points used in this solution",
     ),
     notes: str = typer.Option("", help="Notes for the solution"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Parse inputs and display the resulting Solution without saving",
+    ),
     project_path: Path = typer.Argument(Path("."), help="Project directory"),
 ) -> None:
     """Add a new solution entry for ``event_id``.
@@ -176,6 +181,30 @@ def add_solution(
     sol.log_likelihood = log_likelihood
     sol.log_prior = log_prior
     sol.n_data_points = n_data_points
+
+    if dry_run:
+        parsed = {
+            "event_id": event_id,
+            "model_type": model_type,
+            "parameters": params,
+            "model_name": model_name,
+            "used_astrometry": used_astrometry,
+            "used_postage_stamps": used_postage_stamps,
+            "limb_darkening_model": limb_darkening_model,
+            "limb_darkening_coeffs": _parse_pairs(limb_darkening_coeff),
+            "parameter_uncertainties": _parse_pairs(parameter_uncertainty),
+            "physical_parameters": _parse_pairs(physical_param),
+            "log_likelihood": log_likelihood,
+            "log_prior": log_prior,
+            "n_data_points": n_data_points,
+            "notes": notes,
+        }
+        console.print(Panel("Parsed Input", style="cyan"))
+        console.print(json.dumps(parsed, indent=2))
+        console.print(Panel("Schema Output", style="cyan"))
+        console.print(sol.model_dump_json(indent=2))
+        return
+
     sub.save()
     console.print(f"Created solution: [bold cyan]{sol.solution_id}[/bold cyan]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "microlens-submit"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   { name="Amber Malpas", email="malpas.1@Oosu.edu" },
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -244,6 +244,33 @@ def test_params_file_option_and_model_name():
         assert result.exit_code != 0
 
 
+def test_add_solution_dry_run():
+    """--dry-run prints info without saving to disk."""
+    with runner.isolated_filesystem():
+        assert (
+            runner.invoke(
+                app, ["init", "--team-name", "Team", "--tier", "test"]
+            ).exit_code
+            == 0
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "add-solution",
+                "evt",
+                "model",
+                "--param",
+                "x=1",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Parsed Input" in result.stdout
+        assert "Schema Output" in result.stdout
+        assert not Path("events/evt").exists()
+
+
 def test_cli_activate():
     with runner.isolated_filesystem():
         assert (


### PR DESCRIPTION
## Summary
- document `--dry-run` workflow in README and tutorial
- show `--dry-run` usage in the Jupyter tutorial notebook

## Testing
- `black . --quiet`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68647c71c46883288a360d5385647fed