### PR TITLE
Improve manual file path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Release v0.7.1
+
+### What's New
+- Clarified external file (plots, posteriors) storage and path handling in
+  `SUBMISSION_MANUAL.md`. Internal paths within `solution.json` files in exported
+  archives now point to the file's location inside the zip, allowing immediate
+  use after extraction.
+
+### Bug Fixes
+- None
+
+### Breaking Changes
+- None
+
+### Dependencies
+- No dependency changes
+
+<br>
+
 ## Release v0.7.0
 
 ### What's New

--- a/SUBMISSION_MANUAL.md
+++ b/SUBMISSION_MANUAL.md
@@ -110,6 +110,46 @@ Represents a single model fit.
 > **Note:** Files referenced by `posterior_path`, `lightcurve_plot_path`, and
 > `lens_plane_plot_path` are automatically included in the exported `.zip`.
 
+## 3.1 External File Locations
+
+These optional files must live *inside* your submission directory, and the
+paths stored in each `solution.json` should be **relative** to the submission
+root.  We recommend mirroring the structure that `microlens-submit` itself
+creates:
+
+```text
+<submission_dir>/
+├── submission.json
+└── events/
+    └── <event_id>/
+        ├── event.json
+        └── solutions/
+            ├── <solution_id>.json
+            └── <solution_id>/
+                ├── posterior.h5
+                ├── lightcurve.png
+                └── lens_plane.png
+```
+
+When exported to a `.zip`, these files are copied into the archive following the
+same layout.  The `posterior_path`, `lightcurve_plot_path`, and
+`lens_plane_plot_path` values inside the `solution.json` files in the archive are
+rewritten so that they point to their new location relative to the archive root,
+e.g. `events/<event_id>/solutions/<solution_id>/posterior.h5`.  Be sure to
+extract the archive before running any validation.
+
+Locally, you might reference a posterior file as:
+
+```json
+"posterior_path": "my_runs/posterior.h5"
+```
+
+Inside the exported `.zip`, the same entry becomes:
+
+```json
+"posterior_path": "events/<event_id>/solutions/<solution_id>/posterior.h5"
+```
+
 ## 3\. Validation
 
 Before submitting, you **must** validate your manually created package using the provided `validate_submission.py` script. This is your only safety net.

--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -401,7 +401,18 @@ class Submission(BaseModel):
                         sol_path = event_dir / "solutions" / f"{sol.solution_id}.json"
                         if sol_path.exists():
                             arc = f"events/{event.event_id}/solutions/{sol.solution_id}.json"
-                            zf.write(sol_path, arcname=arc)
+                            export_sol = sol.model_copy()
+                            for attr in [
+                                "posterior_path",
+                                "lightcurve_plot_path",
+                                "lens_plane_plot_path",
+                            ]:
+                                path = getattr(sol, attr)
+                                if path is not None:
+                                    filename = Path(path).name
+                                    new_path = f"events/{event.event_id}/solutions/{sol.solution_id}/{filename}"
+                                    setattr(export_sol, attr, new_path)
+                            zf.writestr(arc, export_sol.model_dump_json(indent=2))
                         # Include any referenced external files
                         sol_dir_arc = (
                             f"events/{event.event_id}/solutions/{sol.solution_id}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import zipfile
+import json
 
 from microlens_submit.api import load
 
@@ -89,6 +90,10 @@ def test_export_includes_external_files(tmp_path):
         assert f"{base}/post.h5" in names
         assert f"{base}/lc.png" in names
         assert f"{base}/lens.png" in names
+        data = json.loads(zf.read(f"{base}.json"))
+        assert data["posterior_path"] == f"{base}/post.h5"
+        assert data["lightcurve_plot_path"] == f"{base}/lc.png"
+        assert data["lens_plane_plot_path"] == f"{base}/lens.png"
 
 
 def test_get_active_solutions(tmp_path):


### PR DESCRIPTION
## Summary
- document how to place extra posterior and plot files
- rewrite solution JSON paths inside exported archives
- test new path rewriting behavior
- add release notes for v0.7.1

## Testing
- `black . --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658538abcc832893df7afbea836189