### PR TITLE
Add relative probability field and calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Release v0.8.0
+
+### What's New
+- Added `relative_probability` field to `Solution` model with CLI and API support.
+- `Submission.export` automatically computes this probability via BIC when not provided, or assigns equal values if BIC inputs are missing.
+- `compare-solutions` now shows relative probabilities and calculates them on demand.
+
+### Bug Fixes
+- None
+
+### Breaking Changes
+- None
+
+### Dependencies
+- N/A
+
+<br>
+
 ## Release v0.7.1
 
 ### What's New

--- a/SUBMISSION_MANUAL.md
+++ b/SUBMISSION_MANUAL.md
@@ -90,6 +90,7 @@ Represents a single model fit.
 |   `physical_parameters`   |  dict   |    No    |               Physical parameters derived from the fit.                |
 |     `log_likelihood`      |  float  |    No    |                   Log-likelihood value for the fit.                    |
 |        `log_prior`        |  float  |    No    |                      Log-prior value for the fit.                      |
+| `relative_probability` |  float  |    No    | Optional relative probability (0-1) that this solution is best. |
 |       `n_data_points`       | integer |    No    |                 Number of data points used in the fit.                 |
 |   `creation_timestamp`    | string  |    No    | ISO timestamp. If omitted, the validator will add a current timestamp. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "microlens-submit"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
   { name="Amber Malpas", email="malpas.1@Oosu.edu" },
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -169,6 +169,29 @@ def test_plot_paths_persist(tmp_path):
     assert new_sol.lens_plane_plot_path == "plots/lens.png"
 
 
+def test_relative_probability_export(tmp_path):
+    project = tmp_path / "proj"
+    sub = load(str(project))
+    evt = sub.get_event("evt")
+    sol1 = evt.add_solution("test", {"a": 1})
+    sol1.log_likelihood = -10
+    sol1.n_data_points = 50
+    sol1.relative_probability = 0.6
+    sol2 = evt.add_solution("test", {"b": 2})
+    sol2.log_likelihood = -12
+    sol2.n_data_points = 50
+    sub.save()
+
+    zip_path = project / "out.zip"
+    sub.export(str(zip_path))
+
+    with zipfile.ZipFile(zip_path) as zf:
+        data1 = json.loads(zf.read(f"events/evt/solutions/{sol1.solution_id}.json"))
+        data2 = json.loads(zf.read(f"events/evt/solutions/{sol2.solution_id}.json"))
+        assert data1["relative_probability"] == 0.6
+        assert abs(data2["relative_probability"] - 0.4) < 1e-6
+
+
 def test_validate_warnings(tmp_path):
     project = tmp_path / "proj"
     sub = load(str(project))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,8 @@ def test_cli_init_and_add():
                 "test",
                 "--param",
                 "p1=1",
+                "--relative-probability",
+                "0.7",
                 "--lightcurve-plot-path",
                 "lc.png",
                 "--lens-plane-plot-path",
@@ -53,6 +55,7 @@ def test_cli_init_and_add():
         assert sol.parameters["p1"] == 1
         assert sol.lightcurve_plot_path == "lc.png"
         assert sol.lens_plane_plot_path == "lens.png"
+        assert sol.relative_probability == 0.7
 
 
 def test_cli_export():
@@ -163,6 +166,7 @@ def test_cli_compare_solutions():
         result = runner.invoke(app, ["compare-solutions", "evt"])
         assert result.exit_code == 0
         assert "BIC" in result.stdout
+        assert "Relative" in result.stdout and "Prob" in result.stdout
 
 
 def test_cli_compare_solutions_skips_zero_data_points():


### PR DESCRIPTION
## Summary
- introduce `relative_probability` to Solution and compute on export
- expose relative probability via CLI add-solution and compare-solutions
- calculate relative probability with BIC or equal fallback
- document new field and release notes
- update notebooks with examples
- bump version to 0.8.0

## Testing
- `black microlens_submit tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686591d1fdb0832897e85f40f7375de7