### PR TITLE
Update model_type values in tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -15,7 +15,7 @@ If your terminal does not support ANSI escape codes, add ``--no-color`` to disab
 
    .. code-block:: bash
 
-      microlens-submit add-solution EVENT123 binary_lens \
+     microlens-submit add-solution EVENT123 1S2L \
           --param t0=555.5 --param u0=0.1 --param tE=25.0 \
           --lightcurve-plot-path plots/event123_lc.png \
           --lens-plane-plot-path plots/event123_lens.png \
@@ -26,7 +26,7 @@ If your terminal does not support ANSI escape codes, add ``--no-color`` to disab
 
    .. code-block:: bash
 
-      microlens-submit add-solution EVENT123 binary_lens \
+     microlens-submit add-solution EVENT123 1S2L \
           --params-file params.json \
           --lightcurve-plot-path plots/event123_lc.png \
           --lens-plane-plot-path plots/event123_lens.png \
@@ -36,7 +36,7 @@ If your terminal does not support ANSI escape codes, add ``--no-color`` to disab
 
    .. code-block:: bash
 
-      microlens-submit add-solution EVENT123 binary_lens \
+     microlens-submit add-solution EVENT123 1S2L \
           --param t0=555.5 --param u0=0.1 --param tE=25.0 \
           --dry-run
 
@@ -60,7 +60,7 @@ If your terminal does not support ANSI escape codes, add ``--no-color`` to disab
 
    .. code-block:: bash
 
-      microlens-submit add-solution EVENT123 single_lens \
+     microlens-submit add-solution EVENT123 1S1L \
           --param t0=556.0 --param u0=0.2 --param tE=24.5
 
 6. **List your solutions**


### PR DESCRIPTION
## Summary
- update tutorial CLI examples to use strongly typed model_type values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b69c1a588328ade9c0deca7c854e