### PR TITLE
Add plot path and probability fields to validator

### DIFF
--- a/validate_submission.py
+++ b/validate_submission.py
@@ -18,6 +18,8 @@ class Solution(BaseModel):
     is_active: bool = True
     compute_info: dict = Field(default_factory=dict)
     posterior_path: Optional[str] = None
+    lightcurve_plot_path: Optional[str] = None
+    lens_plane_plot_path: Optional[str] = None
     notes: str = ""
     used_astrometry: bool = False
     used_postage_stamps: bool = False
@@ -27,6 +29,7 @@ class Solution(BaseModel):
     physical_parameters: Optional[dict] = None
     log_likelihood: Optional[float] = None
     log_prior: Optional[float] = None
+    relative_probability: Optional[float] = None
     n_data_points: Optional[int] = None
     creation_timestamp: str = Field(
         default_factory=lambda: datetime.utcnow().isoformat()


### PR DESCRIPTION
## Summary
- update `validate_submission.py` with `lightcurve_plot_path`, `lens_plane_plot_path` and `relative_probability`
- keep backward compatibility when loading existing submissions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d42653808328859e8bbc23eed0b4