### PR TITLE
Add relative_probability range validation

### DIFF
--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -208,7 +208,8 @@ class Solution(BaseModel):
         # Check solution consistency
         consistency_messages = validate_solution_consistency(
             model_type=self.model_type,
-            parameters=self.parameters
+            parameters=self.parameters,
+            relative_probability=self.relative_probability,
         )
         messages.extend(consistency_messages)
         

--- a/microlens_submit/validate_parameters.py
+++ b/microlens_submit/validate_parameters.py
@@ -297,7 +297,7 @@ def validate_parameter_types(
 def validate_solution_consistency(
     model_type: str,
     parameters: Dict[str, Any],
-    **kwargs
+    **kwargs: Any,
 ) -> List[str]:
     """
     Validate internal consistency of solution parameters.
@@ -305,7 +305,8 @@ def validate_solution_consistency(
     Args:
         model_type: The type of microlensing model
         parameters: Dictionary of model parameters
-        **kwargs: Additional solution attributes
+        **kwargs: Additional solution attributes. Supports
+            ``relative_probability`` for range checking.
         
     Returns:
         List of validation messages
@@ -321,6 +322,10 @@ def validate_solution_consistency(
     
     if 's' in parameters and parameters['s'] <= 0:
         messages.append("Separation (s) must be positive")
+
+    rel_prob = kwargs.get("relative_probability")
+    if rel_prob is not None and not 0 <= rel_prob <= 1:
+        messages.append("Relative probability should be between 0 and 1")
     
     # Check for binary lens specific consistency (1S2L, 2S2L models)
     if model_type in ['1S2L', '2S2L']:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -212,3 +212,15 @@ def test_validate_warnings(tmp_path):
     assert any("log_likelihood" in w for w in warnings)
     assert any("lightcurve_plot_path" in w for w in warnings)
     assert any("lens_plane_plot_path" in w for w in warnings)
+
+
+def test_relative_probability_range(tmp_path):
+    project = tmp_path / "proj"
+    sub = load(str(project))
+    evt = sub.get_event("evt")
+    sol = evt.add_solution("other", {"a": 1})
+    sol.relative_probability = 1.2
+
+    warnings = sub.validate()
+
+    assert any("between 0 and 1" in w for w in warnings)


### PR DESCRIPTION
## Summary
- check `relative_probability` is between 0 and 1 in `validate_solution_consistency`
- propagate relative probability from `Solution.validate`
- test warning for out of range `relative_probability`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d3f8a1f88328b1e03fd4995e33a0