### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,8 @@ repos:
     rev: 5.13.2
     hooks:
     -   id: isort
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+    -   id: flake8

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ sub.export("final_submission.zip")
 The full development plan can be found in agents.md. Contributions are welcome!
 
 To build and test this project, install the development dependencies using either `pip install -e .[dev]` or `pip install -r requirements-dev.txt`. These packages are required to run the test suite and are listed in `requirements-dev.txt`.
-After installing the dependencies, run `pre-commit install` to set up the Git hooks for automatic formatting and linting. The development environment needs the following Python libraries. You can provide these to Codex or set up a `requirements-dev.txt` file.
+After installing the dependencies, run `pre-commit install` to set up the Git hooks for automatic formatting and linting. The development environment needs the following Python libraries.
 
 ### Core Dependencies:
 * **`typer[all]`**: For building the powerful command-line interface. The `[all]` extra ensures shell completion support is included.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ sub.export("final_submission.zip")
 
 The full development plan can be found in agents.md. Contributions are welcome!
 
-To build and test this project, install the development dependencies using either `pip install -e .[dev]` or `pip install -r requirements-dev.txt`. These packages are required to run the test suite and are listed in `requirements-dev.txt`. The development environment needs the following Python libraries. You can provide these to Codex or set up a `requirements-dev.txt` file.
+To build and test this project, install the development dependencies using either `pip install -e .[dev]` or `pip install -r requirements-dev.txt`. These packages are required to run the test suite and are listed in `requirements-dev.txt`.
+After installing the dependencies, run `pre-commit install` to set up the Git hooks for automatic formatting and linting. The development environment needs the following Python libraries. You can provide these to Codex or set up a `requirements-dev.txt` file.
 
 ### Core Dependencies:
 * **`typer[all]`**: For building the powerful command-line interface. The `[all]` extra ensures shell completion support is included.


### PR DESCRIPTION
## Summary
- configure pre-commit with flake8
- mention `pre-commit install` in the development docs

## Testing
- `pytest -q`
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_686b0010bd788328b57df648ac15c148