### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Full documentation is hosted on [Read the Docs](https://microlens-submit.readthe
 
 ## Installation
 
-The package is be available on PyPI:
+The package is available on PyPI:
 
 ```bash
 pip install microlens-submit


### PR DESCRIPTION
## Summary
- fix 'be' typo in README install instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b0053ae6c8328bf30b013c1e80eec