### PR TITLE
Add dossier page unit tests

### DIFF
--- a/tests/test_dossier_pages.py
+++ b/tests/test_dossier_pages.py
@@ -1,0 +1,44 @@
+"""Tests for dossier page generation utilities."""
+
+import pytest
+from pathlib import Path
+
+from microlens_submit.api import load
+from microlens_submit.dossier import _generate_dashboard_content, generate_event_page
+
+
+def _basic_submission(tmp_path: Path):
+    """Create a minimal submission with one event and solution."""
+    sub = load(str(tmp_path))
+    sub.team_name = "UnitTesters"
+    evt = sub.get_event("E001")
+    evt.add_solution("1S1L", {"t0": 0})
+    return sub, evt
+
+
+def test_generate_dashboard_content_contains_event(tmp_path):
+    """Dashboard HTML contains team name and event link."""
+    sub, evt = _basic_submission(tmp_path)
+    html = _generate_dashboard_content(sub)
+    assert f"{evt.event_id}.html" in html
+    assert "UnitTesters" in html
+
+
+def test_generate_event_page_creates_file(tmp_path):
+    """generate_event_page writes an HTML file for the event."""
+    sub, evt = _basic_submission(tmp_path)
+    out_dir = tmp_path / "dossier"
+    out_dir.mkdir()
+    generate_event_page(evt, sub, out_dir)
+    page = out_dir / f"{evt.event_id}.html"
+    assert page.exists()
+    content = page.read_text(encoding="utf-8")
+    assert evt.event_id in content
+
+
+def test_generate_event_page_missing_directory(tmp_path):
+    """Missing output directory raises an error."""
+    sub, evt = _basic_submission(tmp_path)
+    out_dir = tmp_path / "missing"
+    with pytest.raises(FileNotFoundError):
+        generate_event_page(evt, sub, out_dir)


### PR DESCRIPTION
## Summary
- add unit tests for `_generate_dashboard_content` and `generate_event_page`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b004a7064832889dd7443f9ed2250