### PR TITLE
Ensure consistent UTF-8 file handling

### DIFF
--- a/microlens_submit/api.py
+++ b/microlens_submit/api.py
@@ -1858,12 +1858,12 @@ def import_solutions_from_csv(
     # Load parameter mapping if provided
     column_mapping = {}
     if parameter_map_file:
-        with open(parameter_map_file, 'r') as f:
+        with open(parameter_map_file, 'r', encoding='utf-8') as f:
             column_mapping = yaml.safe_load(f)
 
     # Auto-detect delimiter if not specified
     if not delimiter:
-        with open(csv_file, 'r') as f:
+        with open(csv_file, 'r', encoding='utf-8') as f:
             sample = f.read(1024)
             if '\t' in sample:
                 delimiter = '\t'

--- a/microlens_submit/cli.py
+++ b/microlens_submit/cli.py
@@ -1974,7 +1974,7 @@ def import_solutions(
     column_mapping = {}
     if parameter_map_file:
         try:
-            with open(parameter_map_file, 'r') as f:
+            with open(parameter_map_file, 'r', encoding='utf-8') as f:
                 column_mapping = yaml.safe_load(f)
         except Exception as e:
             typer.echo(f"❌ Failed to load parameter map file: {e}")
@@ -1983,7 +1983,7 @@ def import_solutions(
     # Auto-detect delimiter if not specified
     if not delimiter:
         try:
-            with open(csv_file, 'r') as f:
+            with open(csv_file, 'r', encoding='utf-8') as f:
                 sample = f.read(1024)
                 if '\t' in sample:
                     delimiter = '\t'

--- a/microlens_submit/dossier.py
+++ b/microlens_submit/dossier.py
@@ -137,8 +137,8 @@ def _generate_dashboard_content(submission: Submission, full_dossier_exists: boo
         >>> html_content = _generate_dashboard_content(submission)
         >>> 
         >>> # Write to file
-        >>> with open("dashboard.html", "w") as f:
-        ...     f.write(html_content)
+        >>> with open("dashboard.html", "w", encoding="utf-8") as f:
+            ...     f.write(html_content)
     
     Note:
         This is an internal function. Use generate_dashboard_html() for the
@@ -555,8 +555,8 @@ def _generate_event_page_content(event: Event, submission: Submission) -> str:
         >>> html_content = _generate_event_page_content(event, submission)
         >>> 
         >>> # Write to file
-        >>> with open("event_page.html", "w") as f:
-        ...     f.write(html_content)
+        >>> with open("event_page.html", "w", encoding="utf-8") as f:
+            ...     f.write(html_content)
     
     Note:
         Solutions are sorted by: active status (active first), relative
@@ -848,8 +848,8 @@ def _generate_solution_page_content(solution: Solution, event: Event, submission
         >>> html_content = _generate_solution_page_content(solution, event, submission)
         >>> 
         >>> # Write to file
-        >>> with open("solution_page.html", "w") as f:
-        ...     f.write(html_content)
+        >>> with open("solution_page.html", "w", encoding="utf-8") as f:
+            ...     f.write(html_content)
     
     Note:
         Parameter uncertainties are formatted as ±value or +upper/-lower
@@ -1241,7 +1241,7 @@ def _extract_main_content_body(html: str, section_type: str = None, section_id: 
                 if aliases_file.exists():
                     import json
                     try:
-                        with aliases_file.open("r") as f:
+                        with aliases_file.open("r", encoding="utf-8") as f:
                             aliases = json.load(f)
                         # Look up the solution_id in the aliases
                         for key, uuid in aliases.items():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -617,7 +617,7 @@ def test_alias_lookup_table(tmp_path):
     assert alias_file.exists()
     
     # Load and verify the lookup table
-    with alias_file.open("r") as f:
+    with alias_file.open("r", encoding="utf-8") as f:
         alias_lookup = json.load(f)
     
     # Check that all expected aliases are in the lookup table
@@ -713,7 +713,7 @@ def test_alias_in_dossier_generation(tmp_path):
     assert event_page.exists()
     
     # Read the HTML and check for alias display
-    with event_page.open("r") as f:
+    with event_page.open("r", encoding="utf-8") as f:
         html_content = f.read()
     
     # Should show alias as primary identifier
@@ -725,7 +725,7 @@ def test_alias_in_dossier_generation(tmp_path):
     solution_page = dossier_dir / f"{sol.solution_id}.html"
     assert solution_page.exists()
     
-    with solution_page.open("r") as f:
+    with solution_page.open("r", encoding="utf-8") as f:
         sol_html = f.read()
     
     # Should show alias in title and header

--- a/tests/test_dossier_generation.py
+++ b/tests/test_dossier_generation.py
@@ -295,7 +295,7 @@ def main():
     print(f"\n🔍 Testing alias lookup table...")
     alias_file = project_dir / "aliases.json"
     if alias_file.exists():
-        with alias_file.open("r") as f:
+        with alias_file.open("r", encoding="utf-8") as f:
             alias_lookup = json.load(f)
         
         # Check that all expected aliases are in the lookup table


### PR DESCRIPTION
## Summary
- open parameter map and CSV files with UTF-8 encoding
- read aliases.json using UTF-8
- update docstring examples and tests for UTF-8 reads

## Testing
- `black microlens_submit/api.py microlens_submit/cli.py microlens_submit/dossier.py tests/test_api.py tests/test_dossier_generation.py --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b00d11cd483288ab15649482872d5