### PR TITLE
Align standalone validator with core API

### DIFF
--- a/validate_submission.py
+++ b/validate_submission.py
@@ -45,144 +45,18 @@ Note:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
-from datetime import datetime
 from typing import Dict, Optional
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import ValidationError
+
+from microlens_submit.api import Event, Solution, Submission
 
 
-class Solution(BaseModel):
-    """Represents a single microlensing model fit solution.
-
-    This model defines the structure for individual microlensing solutions,
-    including parameters, metadata, file paths, and statistical information.
-    All fields are validated against their expected types and formats.
-
-    **Key Fields:**
-    - solution_id: Unique identifier for the solution
-    - model_type: Type of microlensing model (e.g., "1S1L", "1S2L")
-    - parameters: Dictionary of model parameters
-    - compute_info: Information about computational resources used
-    - file_paths: Paths to posterior data, plots, and notes
-
-    **Optional Features:**
-    - Parameter uncertainties and physical parameters
-    - Astrometry and postage stamp usage flags
-    - Limb darkening models and coefficients
-    - Statistical measures (log-likelihood, relative probability)
-
-    Example:
-        >>> solution = Solution(
-        ...     solution_id="sol_001",
-        ...     model_type="1S1L",
-        ...     parameters={"t0": 2459123.5, "u0": 0.15, "tE": 20.5},
-        ...     log_likelihood=-1234.56,
-        ...     n_data_points=1250,
-        ...     compute_info={"cpu_hours": 2.5, "wall_time_hours": 0.5}
-        ... )
-        >>> print(f"Solution {solution.solution_id} has {len(solution.parameters)} parameters")
-
-    Note:
-        The solution_id should be unique within an event. The model_type
-        should match one of the supported microlensing model types.
-    """
-
-    solution_id: str
-    model_type: str
-    parameters: dict
-    is_active: bool = True
-    compute_info: dict = Field(default_factory=dict)
-    posterior_path: Optional[str] = None
-    lightcurve_plot_path: Optional[str] = None
-    lens_plane_plot_path: Optional[str] = None
-    notes: str = ""
-    used_astrometry: bool = False
-    used_postage_stamps: bool = False
-    limb_darkening_model: Optional[str] = None
-    limb_darkening_coeffs: Optional[dict] = None
-    parameter_uncertainties: Optional[dict] = None
-    physical_parameters: Optional[dict] = None
-    log_likelihood: Optional[float] = None
-    log_prior: Optional[float] = None
-    relative_probability: Optional[float] = None
-    n_data_points: Optional[int] = None
-    creation_timestamp: str = Field(
-        default_factory=lambda: datetime.utcnow().isoformat()
-    )
-
-
-class Event(BaseModel):
-    """Represents a microlensing event with multiple solutions.
-
-    This model defines the structure for individual microlensing events,
-    which can contain multiple solutions from different model fits or
-    analysis approaches.
-
-    **Key Features:**
-    - event_id: Unique identifier for the microlensing event
-    - solutions: Dictionary of Solution objects indexed by solution_id
-    - Support for multiple active/inactive solutions per event
-
-    Example:
-        >>> event = Event(event_id="EVENT001")
-        >>> event.solutions["sol_001"] = Solution(
-        ...     solution_id="sol_001",
-        ...     model_type="1S1L",
-        ...     parameters={"t0": 2459123.5, "u0": 0.15, "tE": 20.5}
-        ... )
-        >>> print(f"Event {event.event_id} has {len(event.solutions)} solutions")
-
-    Note:
-        Events can have multiple solutions, but typically only one should
-        be active per event for final submission. The event_id should
-        match the standard microlensing event naming convention.
-    """
-
-    event_id: str
-    solutions: Dict[str, Solution] = Field(default_factory=dict)
-
-
-class Submission(BaseModel):
-    """Container for all events and metadata in a microlensing submission.
-
-    This is the top-level model that represents an entire microlensing
-    challenge submission. It contains team information, hardware details,
-    and all events with their solutions.
-
-    **Key Components:**
-    - team_name: Name of the submitting team
-    - tier: Challenge tier (e.g., "standard", "advanced")
-    - hardware_info: Computational resources used
-    - events: Dictionary of Event objects indexed by event_id
-
-    **Validation Features:**
-    - Ensures all events have valid structures
-    - Validates team and tier information
-    - Checks hardware information completeness
-
-    Example:
-        >>> submission = Submission(
-        ...     team_name="Team Alpha",
-        ...     tier="advanced",
-        ...     hardware_info={"cpu": "Intel Xeon", "memory_gb": 64}
-        ... )
-        >>> submission.events["EVENT001"] = Event(event_id="EVENT001")
-        >>> print(f"Team {submission.team_name} submitted {len(submission.events)} events")
-
-    Note:
-        The project_path field is excluded from serialization as it's
-        used internally for file path resolution. Hardware information
-        should include details about the computational resources used
-        for the analysis.
-    """
-
-    project_path: str = Field(default="", exclude=True)
-    team_name: str = ""
-    tier: str = ""
-    hardware_info: Optional[dict] = None
-    events: Dict[str, Event] = Field(default_factory=dict)
+# The Solution, Event, and Submission classes are imported from
+# ``microlens_submit.api`` to ensure consistency with the main library.
 
 
 def load_submission(path: str) -> Submission:
@@ -235,7 +109,8 @@ def load_submission(path: str) -> Submission:
         raise FileNotFoundError(f"{sub_json} does not exist")
 
     with sub_json.open("r", encoding="utf-8") as fh:
-        submission = Submission.model_validate_json(fh.read())
+        sub_data = json.load(fh)
+    submission = Submission.model_validate(sub_data)
     submission.project_path = str(project)
 
     events_dir = project / "events"
@@ -246,14 +121,20 @@ def load_submission(path: str) -> Submission:
             event_json = event_dir / "event.json"
             if event_json.exists():
                 with event_json.open("r", encoding="utf-8") as fh:
-                    event = Event.model_validate_json(fh.read())
+                    event_data = json.load(fh)
+                event = Event.model_validate(event_data)
             else:
                 event = Event(event_id=event_dir.name)
+            event.submission = submission
             solutions_dir = event_dir / "solutions"
             if solutions_dir.exists():
                 for sol_file in solutions_dir.glob("*.json"):
                     with sol_file.open("r", encoding="utf-8") as fh:
-                        sol = Solution.model_validate_json(fh.read())
+                        sol_data = json.load(fh)
+                    if "notes" in sol_data and "notes_path" not in sol_data:
+                        sol_data["notes_path"] = sol_data.pop("notes")
+                    sol = Solution.model_validate(sol_data)
+                    sol.saved = True
                     event.solutions[sol.solution_id] = sol
             submission.events[event.event_id] = event
 


### PR DESCRIPTION
## Summary
- import `Event`, `Solution`, and `Submission` from the package API
- remove local model definitions and translate legacy fields
- load JSON via `json.load` to allow field adjustments

## Testing
- `black validate_submission.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b078eaf908328aefc49169ee3c96e